### PR TITLE
package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 build
 *.log
+package-lock.json
 script/javaparser-test/target
 test.java
 /examples/elasticsearch


### PR DESCRIPTION
@maxbrunsfeld Would you take a look this too? Other tree-sitter projects ignore package-lock.json.

- [tree-sitter-ruby's gitignore](https://github.com/tree-sitter/tree-sitter-ruby/blob/master/.gitignore)
- [tree-sitter-python's gitignore](https://github.com/tree-sitter/tree-sitter-python/blob/master/.gitignore)
