### PR TITLE
Add Rust package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Cargo.lock
 node_modules
 build
 *.log
@@ -7,3 +8,4 @@ test.java
 /examples/elasticsearch
 /examples/guava
 /examples/RxJava
+/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ build = "bindings/rust/build.rs"
 include = [
   "bindings/rust/*",
   "grammar.js",
+  "queries/*",
   "src/*",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "tree-sitter-java"
+description = "Java grammar for the tree-sitter parsing library"
+version = "0.16.0"
+authors = [
+    "Douglas Creager <dcreager@dcreager.net>",
+    "Ayman Nadeem <aymannadeem@github.com>",
+]
+license = "MIT"
+readme = "bindings/rust/README.md"
+keywords = ["incremental", "parsing", "java"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-java"
+edition = "2018"
+
+build = "bindings/rust/build.rs"
+include = [
+  "bindings/rust/*",
+  "grammar.js",
+  "src/*",
+]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter = "0.17"
+
+[build-dependencies]
+cc = "1.0"

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -1,0 +1,38 @@
+# tree-sitter-java
+
+This crate provides a Java grammar for the [tree-sitter][] parsing library.  To
+use this crate, add it to the `[dependencies]` section of your `Cargo.toml`
+file.  (Note that you will probably also need to depend on the
+[`tree-sitter`][tree-sitter crate] crate to use the parsed result in any useful
+way.)
+
+``` toml
+[dependencies]
+tree-sitter = "0.17"
+tree-sitter-java = "0.16"
+```
+
+Typically, you will use the [language][language func] function to add this
+grammar to a tree-sitter [Parser][], and then use the parser to parse some code:
+
+``` rust
+let code = r#"
+    class Test {
+        int double(int x) {
+            return x * 2;
+        }
+    }
+"#;
+let mut parser = tree_sitter_java::parser();
+let parsed = parser.parse(code, None);
+```
+
+If you have any questions, please reach out to us in the [tree-sitter
+discussions] page.
+
+[Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+[language func]: https://docs.rs/tree-sitter-java/*/tree_sitter_java/fn.language.html
+[Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+[tree-sitter]: https://tree-sitter.github.io/
+[tree-sitter crate]: https://crates.io/crates/tree-sitter
+[tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -23,7 +23,8 @@ let code = r#"
         }
     }
 "#;
-let mut parser = tree_sitter_java::parser();
+let mut parser = Parser::new();
+parser.set_language(tree_sitter_java::language()).expect("Error loading Java grammar");
 let parsed = parser.parse(code, None);
 ```
 

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,0 +1,17 @@
+use std::path::Path;
+extern crate cc;
+
+fn main() {
+    let src_dir = Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    c_config.compile("parser");
+}

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -48,16 +48,16 @@ pub fn language() -> Language {
 /// The source of the Java tree-sitter grammar description.
 pub const GRAMMAR: &'static str = include_str!("../../grammar.js");
 
-/// The syntax highlighting queries for this language.
-pub const HIGHLIGHT_QUERIES: &'static str = include_str!("../../queries/highlights.scm");
+/// The syntax highlighting query for this language.
+pub const HIGHLIGHT_QUERY: &'static str = include_str!("../../queries/highlights.scm");
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
 pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
-/// The symbol tagging queries for this language.
-pub const TAGGING_QUERIES: &'static str = include_str!("../../queries/tags.scm");
+/// The symbol tagging query for this language.
+pub const TAGGING_QUERY: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,0 +1,65 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2020, tree-sitter-java authors.
+// See the LICENSE file in this repo for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! This crate provides a Java grammar for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this grammar to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! use tree_sitter::Parser;
+//!
+//! let code = r#"
+//!     class Test {
+//!         int double(int x) {
+//!             return x * 2;
+//!         }
+//!     }
+//! "#;
+//! let mut parser = Parser::new();
+//! parser.set_language(tree_sitter_java::language()).expect("Error loading Java grammar");
+//! let parsed = parser.parse(code, None);
+//! # let parsed = parsed.unwrap();
+//! # let root = parsed.root_node();
+//! # assert!(!root.has_error());
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_java() -> Language;
+}
+
+/// Returns the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_java() }
+}
+
+/// The source of the Java tree-sitter grammar description.
+pub const GRAMMAR: &'static str = include_str!("../../grammar.js");
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading Java grammar");
+    }
+}

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -48,10 +48,16 @@ pub fn language() -> Language {
 /// The source of the Java tree-sitter grammar description.
 pub const GRAMMAR: &'static str = include_str!("../../grammar.js");
 
+/// The syntax highlighting queries for this language.
+pub const HIGHLIGHT_QUERIES: &'static str = include_str!("../../queries/highlights.scm");
+
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
 pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+/// The symbol tagging queries for this language.
+pub const TAGGING_QUERIES: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This adds a Rust package for this language grammar.  This makes it easier to use the Rust tree-sitter bindings with a statically known set of languages, since you can just list them as normal Rust dependencies, instead of having to embed the grammar and set up a build.rs file yourself.