### PR TITLE
Fix hard break in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,5 @@ Checklist:
 - [ ] There are sufficient tests for the new fix/feature.
 - [ ] Grammar rules have not been renamed unless absolutely necessary.
 - [ ] The conflicts section hasn't grown too much.
-- [ ] The parser size hasn't grown too much (check the value of
-      STATE_COUNT in src/parser.c).
+- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
       


### PR DESCRIPTION
Before:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [ ] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of
      STATE_COUNT in src/parser.c).

After:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [ ] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
