### PR TITLE
fix digit escape in highlight regex for constants

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -47,7 +47,7 @@
 ; Variables
 
 ((identifier) @constant
- (#match? @constant "^_*[A-Z][A-Z\d_]+"))
+ (#match? @constant "^_*[A-Z][A-Z\\d_]+$"))
 
 (identifier) @variable
 

--- a/test/highlight/types.java
+++ b/test/highlight/types.java
@@ -2,7 +2,10 @@ enum Material {
   //  ^ type
   DENIM,
   // ^ constant
-  CANVAS
+  CANVAS,
+  // ^ constant
+  SPANDEX_3_PERCENT
+  // ^ constant
 }
 
 class Person {


### PR DESCRIPTION
<details><summary>Checklist (:heavy_check_mark:)</summary>

- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature. (added one :+1:)
- [x] Grammar rules have not been renamed unless absolutely necessary. (N/A)
- [x] The conflicts section hasn't grown too much. (N/A)
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c). (N/A)

</details>

I believe this regex escape `"\d"` actually needs to be `"\\d"` to become the digit escape.

**pies.java**

```java
enum Pies {
  APPLE,
  PUMPKIN,
  PI_314
}
```

**query1.scm**

```scm
((identifier) @constant
 (#match? @constant "^_*[A-Z][A-Z\d_]+"))
```

**query2.scm**

```scm
((identifier) @constant
 (#match? @constant "^_*[A-Z][A-Z\d_]+$"))
```

**query3.scm**

```scm
((identifier) @constant
 (#match? @constant "^_*[A-Z][A-Z\\d_]+$"))
```

**reproduction**

```
$ tree-sitter query query1.scm pies.java
pies.java
  pattern: 0
    capture: constant, start: (1, 2), text: "APPLE"
  pattern: 0
    capture: constant, start: (2, 2), text: "PUMPKIN"
  pattern: 0
    capture: constant, start: (3, 2), text: "PI_314"

$ tree-sitter query query2.scm pies.java
pies.java
  pattern: 0
    capture: constant, start: (1, 2), text: "APPLE"
  pattern: 0
    capture: constant, start: (2, 2), text: "PUMPKIN"

$ tree-sitter query query3.scm pies.java
pies.java
  pattern: 0
    capture: constant, start: (1, 2), text: "APPLE"
  pattern: 0
    capture: constant, start: (2, 2), text: "PUMPKIN"
  pattern: 0
    capture: constant, start: (3, 2), text: "PI_314"

```

`query1.scm` is the current query rule, and it works but only because it doesn't end in `$`, so in theory other characters could end up matching the query than digits. `query2.scm` shows that the `\d` escape doesn't work: it fails to match the constant with digits. `query3.scm` switches to `\\d` with the trailing `$` and it works again!

It looks like there's one of these `\d`s in the php queries (pr incoming...) but elsewhere there're `\\d`s (e.g. [this ruby query](https://github.com/tree-sitter/tree-sitter-ruby/blob/1fedb2a117f89b7df05550255a022f6e25bb7975/queries/highlights.scm#L63-L64))