### PR TITLE
Run workflow on `pull_request`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Build/test
 on:
+  pull_request:
+    branches:
+      - "**"
   push:
     branches:
       - "**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - "**"
   push:
     branches:
-      - "**"
+      - "master"
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 name: Build/test
 on:
   pull_request:
-    branches:
-      - "**"
   push:
-    branches:
-      - "master"
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
👋 @maxbrunsfeld,  it looks like the workflow file was configured to only run on `push` and not on both `push` and `pull_request`.  I think it's likely that opening a PR,  but not subsequently pushing to that branch would result in CI not running.

Checklist:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [ ] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
      
