### PR TITLE
Allow rust crate compatibility with 0.19 and 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-java"
 description = "Java grammar for the tree-sitter parsing library"
-version = "0.19.0"
+version = "0.20.0"
 authors = [
     "Douglas Creager <dcreager@dcreager.net>",
     "Ayman Nadeem <aymannadeem@github.com>",
@@ -25,7 +25,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19"
+tree-sitter = ">= 0.19, < 0.21"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
This PR changes the version requirements for the rust crate to a range that includes tree-sitter 0.19 and 0.20.

I have not updated the package.json because I don't understand it and that can be done independently anyway.

Kind of replaces #84 at least for the rust part.