### PR TITLE
Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test.java
 *.o
 bindings/c/*.h
 bindings/c/tree-sitter-*.pc
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,12 @@ let package = Package(
                     "corpus",
                     "grammar.js",
                     "LICENSE",
+                    "Makefile",
                     "package.json",
                     "README.md",
+                    "script",
+                    "src/grammar.json",
+                    "src/node-types.json",
                 ],
                 sources: [
                     "src/parser.c",
@@ -29,4 +33,4 @@ let package = Package(
                 publicHeadersPath: "bindings/swift",
                 cSettings: [.headerSearchPath("src")])
     ]
-) 
+)

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterJava",
+    products: [
+        .library(name: "TreeSitterJava", targets: ["TreeSitterJava"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterJava",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "corpus",
+                    "grammar.js",
+                    "LICENSE",
+                    "package.json",
+                    "README.md",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.cc",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+) 

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,6 @@ let package = Package(
                 ],
                 sources: [
                     "src/parser.c",
-                    "src/scanner.cc",
                 ],
                 resources: [
                     .copy("queries")

--- a/bindings/swift/TreeSitterJava/java.h
+++ b/bindings/swift/TreeSitterJava/java.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_JAVA_H_
+#define TREE_SITTER_JAVA_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_java();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_JAVA_H_ 


### PR DESCRIPTION
Swift's package manager can build C/C++ sources and use headers to expose functions to Swift. The standard tree-sitter parser project layout just requires a little extra configuration to make it happy.
      
