### PR TITLE
Adds GH tags queries

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,20 +1,110 @@
-(class_declaration
-  name: (identifier) @name) @definition.class
+(class_declaration name: (identifier) @name) @definition.class
 
-(method_declaration
-  name: (identifier) @name) @definition.method
+(method_declaration name: (identifier) @name) @definition.method
 
-(method_invocation
-  name: (identifier) @name
-  arguments: (argument_list) @reference.call)
+(method_invocation name: (identifier) @name arguments: (argument_list) @reference.call)
 
-(interface_declaration
-  name: (identifier) @name) @definition.interface
+(interface_declaration name: (identifier) @name) @definition.interface
 
-(type_list
-  (type_identifier) @name) @reference.implementation
+(type_list (type_identifier) @name) @reference.implementation
 
-(object_creation_expression
-  type: (type_identifier) @name) @reference.class
+(object_creation_expression type: (type_identifier) @name) @reference.class
 
 (superclass (type_identifier) @name) @reference.class
+
+(constructor_declaration name: (identifier) @name) @definition.method
+
+(field_declaration declarator: (variable_declarator name: (identifier) @name)) @definition.field
+
+
+
+
+
+(
+  (comment)* @doc
+  .
+  (method_definition
+    name: (property_identifier) @name) @definition.method
+  (#not-eq? @name "constructor")
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.method)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (class
+      name: (_) @name)
+    (class_declaration
+      name: (_) @name)
+  ] @definition.class
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.class)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (function
+      name: (identifier) @name)
+    (function_declaration
+      name: (identifier) @name)
+    (generator_function
+      name: (identifier) @name)
+    (generator_function_declaration
+      name: (identifier) @name)
+  ] @definition.function
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: [(arrow_function) (function)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (variable_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: [(arrow_function) (function)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(assignment_expression
+  left: [
+    (identifier) @name
+    (member_expression
+      property: (property_identifier) @name)
+  ]
+  right: [(arrow_function) (function)]
+) @definition.function
+
+(pair
+  key: (property_identifier) @name
+  value: [(arrow_function) (function)]) @definition.function
+
+(new_expression
+  constructor: (_) @name) @reference.class
+
+(export_statement value: (assignment_expression left: (identifier) @name right: ([
+ (number)
+ (string)
+ (identifier)
+ (undefined)
+ (null)
+ (new_expression)
+ (binary_expression)
+ (call_expression)
+]))) @definition.constant


### PR DESCRIPTION
This PR adds new tags queries to `tags.scm` to support code search on Github.com.

Checklist:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [ ] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
      
