### PR TITLE
Add `record` as a keyword to highlight

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -122,6 +122,7 @@
   "provides"
   "public"
   "requires"
+  "record"
   "return"
   "sealed"
   "static"


### PR DESCRIPTION
`record` wasn't previously highlighted as a keyword.

(Removed checklist as this isn't a grammar change.)
