### PR TITLE
Prevent mangled URL in .pc file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,11 @@ ifeq (, $(PARSER_NAME))
 endif
 
 ifeq (, $(PARSER_URL))
-	PARSER_URL := $(subst :,/,$(PARSER_REPO_URL))
+	PARSER_URL := $(subst .git,,$(PARSER_REPO_URL))
+ifeq ($(shell echo $(PARSER_URL) | grep '^[a-z][-+.0-9a-z]*://'),)
+	PARSER_URL := $(subst :,/,$(PARSER_URL))
 	PARSER_URL := $(subst git@,https://,$(PARSER_URL))
-	PARSER_URL := $(subst .git,,$(PARSER_URL))
+endif
 endif
 
 UPPER_PARSER_NAME := $(shell echo $(PARSER_NAME) | tr a-z A-Z )


### PR DESCRIPTION
Previously, the `Makefile` assumed that Git URLs were always “SSH style”, e.g., `git@github.com:tree-sitter/tree-sitter-java.git`.  This change causes the right thing to be done when a normal URL is encountered, e.g. `https://github.com/tree-sitter/tree-sitter-java.git`.

Relates to https://bugzilla.redhat.com/show_bug.cgi?id=2193261



Checklist:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.  _There do not appear to be any existing tests for this._
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
      
