### PR TITLE
feat(grammar): Refactor modifiers for better querying

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -887,11 +887,13 @@ module.exports = grammar({
       field('body', $.class_body),
     ),
 
-    modifiers: $ => repeat1(choice(
-      $._annotation,
+    visibility: $ => choice(
       'public',
       'protected',
       'private',
+    ),
+
+    _modifier: $ => choice(
       'abstract',
       'static',
       'final',
@@ -903,6 +905,12 @@ module.exports = grammar({
       'volatile',
       'sealed',
       'non-sealed',
+    ),
+
+    modifiers: $ => repeat1(choice(
+      $._annotation,
+      $.visibility,
+      alias($._modifier, $.modifier),
     )),
 
     type_parameters: $ => seq(


### PR DESCRIPTION
Addresses #204.

Right now, modifiers like `public` or `static` are just anonymous keywords in the AST. This makes it a pain to write queries for them without matching on text.

This PR makes them actual nodes, similar to how `tree-sitter-typescript` handles it.

**Changes:**

1.  **New `(visibility)` node:**
    -   `public`, `protected`, `private` are now grouped under this node.
    -   Makes it easy to find declarations with specific visibility.
    ```scheme
    ; e.g., find public methods
    (method_declaration (modifiers (visibility) @v) (#eq? @v "public"))
    ```

2.  **New `(modifier)` node:**
    -   `static`, `final`, `abstract`, etc., now all produce a `(modifier)` node.
    -   This provides a single node type for all these other keywords.
    ```scheme
    ; e.g., find static fields
    (field_declaration (modifiers (modifier) @m) (#eq? @m "static"))
    ```

**Resulting AST:**

For `public static class...`, the AST is now much cleaner:

```diff
- (modifiers (KEYWORD) (KEYWORD))
+ (modifiers
+   (visibility)
+   (modifier)
+ )
```

Closes #204.